### PR TITLE
Add better debug options and prevent overflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,4 @@ dist-clean:
 mt:
 	gcc -Wall mactelnet.c md5.c -o mactelnet -I/usr/local/include/libnet11 -L/usr/local/lib/libnet11 -lnet -lpcap
 debug:
-	gcc -Wall mactelnet.c md5.c -o mactelnet -I/usr/local/include/libnet11 -L/usr/local/lib/libnet11 -lnet -lpcap -D__DEBUG
+	gcc -Wall mactelnet.c md5.c -o mactelnet -I/usr/local/include/libnet11 -L/usr/local/lib/libnet11 -lnet -lpcap -O0 -g -D__DEBUG

--- a/mactelnet.c
+++ b/mactelnet.c
@@ -554,15 +554,24 @@ static void handle_mndp(u_int8_t *args, struct pcap_pkthdr *header, u_int8_t *pa
     }
 
     p += len;
+    if (p-packet > header->caplen) {
+#ifdef __DEBUG
+      printf("Length mismatch, skipping\n");
+#endif
+      break;
+    }
     i += len + 3;
   }
 
-  memcpy(&ip, &ipv4_hdr->ip_src.s_addr, 4);
+  if (ipv4_hdr->ip_p == IPPROTO_UDP)
+  {
+    memcpy(&ip, &ipv4_hdr->ip_src.s_addr, 4);
 #if BYTE_ORDER == LITTLE_ENDIAN
-  ip = ntohl(ip);
+    ip = ntohl(ip);
 #endif
-  p = (u_int8_t *)&ip;
-  printf("%u.%u.%u.%u\n", p[3], p[2], p[1], p[0]);
+    p = (u_int8_t *)&ip;
+    printf("IP: %u.%u.%u.%u\n", p[3], p[2], p[1], p[0]);
+  }
 }
 
 


### PR DESCRIPTION
Some corrupted packets caused buffer overflow & core dump due incorrect length pointer. Add simple check to solve that.
Also add options for debug build for easier valgrind/gdb troubleshooting